### PR TITLE
save current tab in onStop rather than onDestroy

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
@@ -78,8 +78,8 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onStop() {
+        super.onStop()
         config.lastUsedViewPagerPage = view_pager.currentItem
     }
 


### PR DESCRIPTION
onDestroy may or may not be called, but it's often not.
Remembering the last selected tab did not work at all for me.