### PR TITLE
Fix alarm not vibrating when activiting the ReminderService

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Context.kt
@@ -314,9 +314,7 @@ fun Context.getHideAlarmPendingIntent(alarm: Alarm): PendingIntent {
 @SuppressLint("NewApi")
 fun Context.getAlarmNotification(pendingIntent: PendingIntent, alarm: Alarm): Notification {
     var soundUri = alarm.soundUri
-    if (soundUri == SILENT) {
-        soundUri = ""
-    } else {
+    if (soundUri != SILENT) {
         grantReadUriPermission(soundUri)
     }
 
@@ -350,12 +348,15 @@ fun Context.getAlarmNotification(pendingIntent: PendingIntent, alarm: Alarm): No
         .setPriority(Notification.PRIORITY_HIGH)
         .setDefaults(Notification.DEFAULT_LIGHTS)
         .setAutoCancel(true)
-        .setSound(Uri.parse(soundUri), AudioManager.STREAM_ALARM)
         .setChannelId(channelId)
         .addAction(R.drawable.ic_snooze_vector, getString(R.string.snooze), getSnoozePendingIntent(alarm))
         .addAction(R.drawable.ic_cross_vector, getString(R.string.dismiss), getHideAlarmPendingIntent(alarm))
 
-    builder.setVisibility(Notification.VISIBILITY_PUBLIC)
+    builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+
+    if (soundUri != SILENT) {
+        builder.setSound(Uri.parse(soundUri), AudioManager.STREAM_ALARM);
+    }
 
     if (alarm.vibrate) {
         val vibrateArray = LongArray(2) { 500 }


### PR DESCRIPTION
I noticed (unfortunately) that an alarm I've set did not go off. Upon opening the app it showed me the alarm screen but with a toast showing the error `setDataSource invalid` (issue #139). This PR fixes this issue.

## Cause

If the app is closed and/or the device is sleeping, the alarm will launch the `ReminderActivity` once the time of the alarm has come. But there were two bugs at play here:
1. If the alarm sound is set to "(no sound)", it will use the string `silent` as the sound URL for the media player. As this does not refer to an actual sound file, it causes the media player to throw the error shown.
2. The `ReminderActivity` did not have any code to let the device vibrate.

While looking around a third bug was found:
3. In the context, it would create the alarm notification but again pass the placeholder `silent` value to the notification.

## Solution
1. Before launching the player, we perform a check if the URL is equal to the placeholder value `silent`. If that is the case, we do not need to start the media player.
2. The `setupAudio` method is renamed to `setupEffects` and code is added to let the device vibrate. Similarly `destroyAudio` is renamed to `destroyEffects` and it stops the device vibration.
3. The same check as in 1 is done in the `Context` creating the alarm notification.

**Note:** I don't have much experience in android development, so any tips or remarks are welcome! 