### PR TITLE
Update Simple-Commons and remove useless annotations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:307941253d'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:eee4809d37'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'com.shawnlin:number-picker:2.4.6'

--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
@@ -77,7 +77,7 @@ class ReminderActivity : SimpleActivity() {
         }
     }
 
-    @SuppressLint("NewApi")
+    @SuppressLint("ClickableViewAccessibility")
     private fun setupAlarmButtons() {
         reminder_stop.beGone()
         reminder_draggable_background.startAnimation(AnimationUtils.loadAnimation(this, R.anim.pulsing_animation))

--- a/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Context.kt
@@ -1,6 +1,5 @@
 package com.simplemobiletools.clock.extensions
 
-import android.annotation.SuppressLint
 import android.app.*
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
@@ -182,7 +181,6 @@ fun Context.updateWidgets() {
     }
 }
 
-@SuppressLint("NewApi")
 fun Context.scheduleNextWidgetUpdate() {
     val widgetsCnt =
         AppWidgetManager.getInstance(applicationContext)?.getAppWidgetIds(ComponentName(applicationContext, MyWidgetDateTimeProvider::class.java)) ?: return
@@ -267,7 +265,6 @@ fun Context.showAlarmNotification(alarm: Alarm) {
     }
 }
 
-@SuppressLint("NewApi")
 fun Context.getTimerNotification(timer: Timer, pendingIntent: PendingIntent, addDeleteIntent: Boolean): Notification {
     var soundUri = timer.soundUri
     if (soundUri == SILENT) {
@@ -351,7 +348,6 @@ fun Context.getHideAlarmPendingIntent(alarm: Alarm): PendingIntent {
     return PendingIntent.getBroadcast(this, alarm.id, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 }
 
-@SuppressLint("NewApi")
 fun Context.getAlarmNotification(pendingIntent: PendingIntent, alarm: Alarm): Notification {
     val soundUri = alarm.soundUri
     if (soundUri != SILENT) {

--- a/app/src/main/kotlin/com/simplemobiletools/clock/receivers/AlarmReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/receivers/AlarmReceiver.kt
@@ -1,6 +1,5 @@
 package com.simplemobiletools.clock.receivers
 
-import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -21,7 +20,6 @@ import com.simplemobiletools.commons.helpers.isOreoPlus
 
 class AlarmReceiver : BroadcastReceiver() {
 
-    @SuppressLint("NewApi")
     override fun onReceive(context: Context, intent: Intent) {
         val id = intent.getIntExtra(ALARM_ID, -1)
         val alarm = context.dbHelper.getAlarmWithId(id) ?: return

--- a/app/src/main/kotlin/com/simplemobiletools/clock/services/TimerService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/services/TimerService.kt
@@ -9,8 +9,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import com.simplemobiletools.clock.R
 import com.simplemobiletools.clock.extensions.getFormattedDuration
 import com.simplemobiletools.clock.extensions.getOpenTimerTabIntent
@@ -118,13 +118,8 @@ class TimerService : Service() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 fun startTimerService(context: Context) {
-    if (isOreoPlus()) {
-        context.startForegroundService(Intent(context, TimerService::class.java))
-    } else {
-        context.startService(Intent(context, TimerService::class.java))
-    }
+    ContextCompat.startForegroundService(context, Intent(context, TimerService::class.java))
 }
 
 object TimerStopService

--- a/app/src/main/kotlin/com/simplemobiletools/clock/services/TimerService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/services/TimerService.kt
@@ -1,13 +1,11 @@
 package com.simplemobiletools.clock.services
 
-import android.annotation.TargetApi
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -86,7 +84,6 @@ class TimerService : Service() {
         bus.unregister(this)
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     private fun notification(title: String, contentText: String, firstRunningTimerId: Int): Notification {
         val channelId = "simple_alarm_timer"
         val label = getString(R.string.timer)


### PR DESCRIPTION
The reason they were needed was the linter couldn't understand
their usage when they aren't in the same project but with the
updated Simple-Commons it now can.

This is why I needed https://github.com/SimpleMobileTools/Simple-Commons/pull/1230 hope it now makes sense more to you. Thanks