### PR TITLE
Migrate to ViewPager2

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
@@ -139,6 +139,7 @@ class MainActivity : SimpleActivity() {
     private fun initFragments() {
         val viewPagerAdapter = ViewPagerAdapter(this)
         view_pager.adapter = viewPagerAdapter
+        view_pager.offscreenPageLimit = TABS_COUNT - 1
         view_pager.onPageChangeListener {
             main_tabs_holder.getTabAt(it)?.select()
             invalidateOptionsMenu()
@@ -151,8 +152,7 @@ class MainActivity : SimpleActivity() {
             viewPagerAdapter.updateTimerPosition(timerId)
         }
 
-        view_pager.offscreenPageLimit = TABS_COUNT - 1
-        view_pager.currentItem = tabToOpen
+        view_pager.setCurrentItem(tabToOpen, false)
     }
 
     private fun setupTabs() {

--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import com.simplemobiletools.clock.BuildConfig
 import com.simplemobiletools.clock.R
 import com.simplemobiletools.clock.adapters.ViewPagerAdapter
@@ -18,8 +19,14 @@ import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.models.FAQItem
 import kotlinx.android.synthetic.main.activity_main.*
 import me.grantland.widget.AutofitHelper
+import kotlin.math.abs
+import kotlin.math.min
+import kotlin.math.roundToLong
 
 class MainActivity : SimpleActivity() {
+    private val SCROLL_DURATION = 120f
+    private val MAX_SETTLE_DURATION = 600f
+
     private var storedTextColor = 0
     private var storedBackgroundColor = 0
     private var storedPrimaryColor = 0
@@ -173,9 +180,13 @@ class MainActivity : SimpleActivity() {
             tabUnselectedAction = {
                 updateBottomTabItemColors(it.customView, false)
             },
-            tabSelectedAction = {
-                view_pager.currentItem = it.position
-                updateBottomTabItemColors(it.customView, true)
+            tabSelectedAction = { tab ->
+                if (!view_pager.isFakeDragging && view_pager.scrollState == SCROLL_STATE_IDLE) {
+                    val distance = abs(tab.position - view_pager.currentItem)
+                    val duration = min(MAX_SETTLE_DURATION, SCROLL_DURATION * distance).roundToLong()
+                    view_pager.smoothScrollToPosition(tab.position, duration = duration)
+                }
+                updateBottomTabItemColors(tab.customView, true)
             }
         )
     }

--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/MainActivity.kt
@@ -11,10 +11,7 @@ import android.widget.TextView
 import com.simplemobiletools.clock.BuildConfig
 import com.simplemobiletools.clock.R
 import com.simplemobiletools.clock.adapters.ViewPagerAdapter
-import com.simplemobiletools.clock.extensions.config
-import com.simplemobiletools.clock.extensions.getNextAlarm
-import com.simplemobiletools.clock.extensions.rescheduleEnabledAlarms
-import com.simplemobiletools.clock.extensions.updateWidgets
+import com.simplemobiletools.clock.extensions.*
 import com.simplemobiletools.clock.helpers.*
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
@@ -140,7 +137,7 @@ class MainActivity : SimpleActivity() {
     private fun getViewPagerAdapter() = view_pager.adapter as? ViewPagerAdapter
 
     private fun initFragments() {
-        val viewPagerAdapter = ViewPagerAdapter(supportFragmentManager)
+        val viewPagerAdapter = ViewPagerAdapter(this)
         view_pager.adapter = viewPagerAdapter
         view_pager.onPageChangeListener {
             main_tabs_holder.getTabAt(it)?.select()

--- a/app/src/main/kotlin/com/simplemobiletools/clock/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/adapters/ViewPagerAdapter.kt
@@ -1,9 +1,8 @@
 package com.simplemobiletools.clock.adapters
 
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.simplemobiletools.clock.fragments.AlarmFragment
 import com.simplemobiletools.clock.fragments.ClockFragment
 import com.simplemobiletools.clock.fragments.StopwatchFragment
@@ -14,21 +13,16 @@ import com.simplemobiletools.clock.helpers.TAB_CLOCK
 import com.simplemobiletools.clock.helpers.TAB_TIMER
 import com.simplemobiletools.commons.models.AlarmSound
 
-class ViewPagerAdapter(fm: FragmentManager) : FragmentStatePagerAdapter(fm) {
+class ViewPagerAdapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {
     private val fragments = HashMap<Int, Fragment>()
 
-    override fun getItem(position: Int): Fragment {
+    override fun createFragment(position: Int): Fragment {
         val fragment = getFragment(position)
         fragments[position] = fragment
         return fragment
     }
 
-    override fun destroyItem(container: ViewGroup, position: Int, item: Any) {
-        fragments.remove(position)
-        super.destroyItem(container, position, item)
-    }
-
-    override fun getCount() = TABS_COUNT
+    override fun getItemCount() = TABS_COUNT
 
     private fun getFragment(position: Int) = when (position) {
         0 -> ClockFragment()

--- a/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Fragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/extensions/Fragment.kt
@@ -5,6 +5,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceManager
 
-val Fragment.requiredActivity: FragmentActivity get() = this.activity!!
+val Fragment.requiredActivity: FragmentActivity get() = requireActivity()
 
 val Fragment.preferences: SharedPreferences get() = PreferenceManager.getDefaultSharedPreferences(requiredActivity)
+
+val Fragment.isReady: Boolean get() = activity != null && context != null && isAdded

--- a/app/src/main/kotlin/com/simplemobiletools/clock/extensions/ViewPager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/extensions/ViewPager.kt
@@ -1,0 +1,16 @@
+package com.simplemobiletools.clock.extensions
+
+import androidx.viewpager2.widget.ViewPager2
+
+// todo: maybe move to simple-commons later
+fun ViewPager2.onPageChangeListener(pageChangedAction: (newPosition: Int) -> Unit) {
+    registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+        override fun onPageScrollStateChanged(state: Int) {}
+
+        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
+
+        override fun onPageSelected(position: Int) {
+            pageChangedAction(position)
+        }
+    })
+}

--- a/app/src/main/kotlin/com/simplemobiletools/clock/extensions/ViewPager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/extensions/ViewPager.kt
@@ -1,5 +1,10 @@
 package com.simplemobiletools.clock.extensions
 
+import android.animation.Animator
+import android.animation.TimeInterpolator
+import android.animation.ValueAnimator
+import android.util.LayoutDirection
+import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.viewpager2.widget.ViewPager2
 
 // todo: maybe move to simple-commons later
@@ -13,4 +18,36 @@ fun ViewPager2.onPageChangeListener(pageChangedAction: (newPosition: Int) -> Uni
             pageChangedAction(position)
         }
     })
+}
+
+fun ViewPager2.smoothScrollToPosition(
+    item: Int,
+    duration: Long = 300L,
+    interpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
+    pagePxWidth: Int = width
+) {
+    val pxToDrag: Int = pagePxWidth * (item - currentItem)
+    val animator = ValueAnimator.ofInt(0, pxToDrag)
+    var previousValue = 0
+    animator.addUpdateListener { valueAnimator ->
+        val currentValue = valueAnimator.animatedValue as Int
+        val currentPxToDrag = (currentValue - previousValue).toFloat()
+        if (layoutDirection == LayoutDirection.RTL) fakeDragBy(currentPxToDrag) else fakeDragBy(-currentPxToDrag)
+        previousValue = currentValue
+    }
+    animator.addListener(object : Animator.AnimatorListener {
+        override fun onAnimationStart(animation: Animator?) {
+            beginFakeDrag()
+        }
+
+        override fun onAnimationEnd(animation: Animator?) {
+            endFakeDrag()
+        }
+
+        override fun onAnimationCancel(animation: Animator?) {}
+        override fun onAnimationRepeat(animation: Animator?) {}
+    })
+    animator.interpolator = interpolator
+    animator.duration = duration
+    animator.start()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/AlarmFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/AlarmFragment.kt
@@ -37,14 +37,14 @@ class AlarmFragment : Fragment(), ToggleAlarmInterface {
         return view
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupViews()
+    }
+
     override fun onResume() {
         super.onResume()
         setupViews()
-
-        val configTextColor = requireContext().getProperTextColor()
-        if (storedTextColor != configTextColor) {
-            (view.alarms_list.adapter as AlarmsAdapter).updateTextColor(configTextColor)
-        }
     }
 
     override fun onPause() {
@@ -74,6 +74,10 @@ class AlarmFragment : Fragment(), ToggleAlarmInterface {
         }
 
         setupAlarms()
+        val configTextColor = requireContext().getProperTextColor()
+        if (storedTextColor != configTextColor) {
+            (view.alarms_list.adapter as AlarmsAdapter).updateTextColor(configTextColor)
+        }
     }
 
     private fun setupAlarms() {

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/AlarmFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/AlarmFragment.kt
@@ -37,8 +37,8 @@ class AlarmFragment : Fragment(), ToggleAlarmInterface {
         return view
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onStart() {
+        super.onStart()
         setupViews()
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
@@ -18,7 +18,6 @@ import com.simplemobiletools.clock.models.MyTimeZone
 import com.simplemobiletools.commons.extensions.beVisibleIf
 import com.simplemobiletools.commons.extensions.getProperTextColor
 import com.simplemobiletools.commons.extensions.updateTextColors
-import kotlinx.android.synthetic.main.fragment_clock.*
 import kotlinx.android.synthetic.main.fragment_clock.view.*
 import java.util.*
 
@@ -39,16 +38,14 @@ class ClockFragment : Fragment() {
         return view
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupDateTime()
+    }
+
     override fun onResume() {
         super.onResume()
         setupDateTime()
-
-        val configTextColor = requireContext().getProperTextColor()
-        if (storedTextColor != configTextColor) {
-            (view.time_zones_list.adapter as? TimeZonesAdapter)?.updateTextColor(configTextColor)
-        }
-
-        view.clock_date.setTextColor(configTextColor)
     }
 
     override fun onPause() {
@@ -72,13 +69,18 @@ class ClockFragment : Fragment() {
 
     private fun setupViews() {
         view.apply {
+            val configTextColor = requireContext().getProperTextColor()
             requireContext().updateTextColors(clock_fragment)
-            clock_time.setTextColor(requireContext().getProperTextColor())
+            clock_time.setTextColor(configTextColor)
             clock_fab.setOnClickListener {
                 fabClicked()
             }
 
             updateTimeZones()
+            if (storedTextColor != configTextColor) {
+                (time_zones_list.adapter as? TimeZonesAdapter)?.updateTextColor(configTextColor)
+            }
+            clock_date.setTextColor(configTextColor)
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
@@ -38,8 +38,8 @@ class ClockFragment : Fragment() {
         return view
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onStart() {
+        super.onStart()
         setupDateTime()
     }
 
@@ -103,7 +103,9 @@ class ClockFragment : Fragment() {
 
         updateHandler.postDelayed({
             passedSeconds++
-            updateCurrentTime()
+            if (isReady) {
+                updateCurrentTime()
+            }
         }, ONE_SECOND)
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
@@ -80,6 +80,7 @@ class StopwatchFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         setupViews()
+        Stopwatch.addUpdateListener(updateListener)
         setupStopwatch()
     }
 
@@ -92,6 +93,10 @@ class StopwatchFragment : Fragment() {
     override fun onPause() {
         super.onPause()
         storeStateVariables()
+    }
+
+    override fun onStop() {
+        super.onStop()
         Stopwatch.removeUpdateListener(updateListener)
     }
 
@@ -114,7 +119,6 @@ class StopwatchFragment : Fragment() {
     }
 
     private fun setupStopwatch() {
-        Stopwatch.addUpdateListener(updateListener)
         updateLaps()
         view.stopwatch_sorting_indicators_holder.beVisibleIf(Stopwatch.laps.isNotEmpty())
         if (Stopwatch.laps.isNotEmpty()) {

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
@@ -76,21 +76,16 @@ class StopwatchFragment : Fragment() {
         return view
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupViews()
+        setupStopwatch()
+    }
+
     override fun onResume() {
         super.onResume()
         setupViews()
-
-        val configTextColor = requireContext().getProperTextColor()
-        if (storedTextColor != configTextColor) {
-            stopwatchAdapter.updateTextColor(configTextColor)
-        }
-
-        Stopwatch.addUpdateListener(updateListener)
-        updateLaps()
-        view.stopwatch_sorting_indicators_holder.beVisibleIf(Stopwatch.laps.isNotEmpty())
-        if (Stopwatch.laps.isNotEmpty()) {
-            updateSorting(Lap.sorting)
-        }
+        setupStopwatch()
     }
 
     override fun onPause() {
@@ -105,10 +100,24 @@ class StopwatchFragment : Fragment() {
 
     private fun setupViews() {
         val properPrimaryColor = requireContext().getProperPrimaryColor()
+        val configTextColor = requireContext().getProperTextColor()
         view.apply {
             requireContext().updateTextColors(stopwatch_fragment)
             stopwatch_play_pause.background = resources.getColoredDrawableWithColor(R.drawable.circle_background_filled, properPrimaryColor)
-            stopwatch_reset.applyColorFilter(requireContext().getProperTextColor())
+            stopwatch_reset.applyColorFilter(configTextColor)
+        }
+
+        if (storedTextColor != configTextColor) {
+            stopwatchAdapter.updateTextColor(configTextColor)
+        }
+    }
+
+    private fun setupStopwatch() {
+        Stopwatch.addUpdateListener(updateListener)
+        updateLaps()
+        view.stopwatch_sorting_indicators_holder.beVisibleIf(Stopwatch.laps.isNotEmpty())
+        if (Stopwatch.laps.isNotEmpty()) {
+            updateSorting(Lap.sorting)
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
@@ -13,6 +13,7 @@ import com.simplemobiletools.clock.activities.SimpleActivity
 import com.simplemobiletools.clock.adapters.StopwatchAdapter
 import com.simplemobiletools.clock.extensions.config
 import com.simplemobiletools.clock.extensions.formatStopwatchTime
+import com.simplemobiletools.clock.extensions.isReady
 import com.simplemobiletools.clock.helpers.SORT_BY_LAP
 import com.simplemobiletools.clock.helpers.SORT_BY_LAP_TIME
 import com.simplemobiletools.clock.helpers.SORT_BY_TOTAL_TIME
@@ -76,8 +77,8 @@ class StopwatchFragment : Fragment() {
         return view
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onStart() {
+        super.onStart()
         setupViews()
         setupStopwatch()
     }
@@ -199,6 +200,10 @@ class StopwatchFragment : Fragment() {
         }
 
         override fun onStateChanged(state: Stopwatch.State) {
+            if (!isReady) {
+                // avoid accessing context when fragment isn't attached
+                return
+            }
             updateIcons(state)
             view.stopwatch_lap.beVisibleIf(state == Stopwatch.State.RUNNING)
             view.stopwatch_reset.beVisibleIf(state != Stopwatch.State.STOPPED)

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/TimerFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/TimerFragment.kt
@@ -75,8 +75,8 @@ class TimerFragment : Fragment() {
         view.timers_list.adapter = timerAdapter
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onStart() {
+        super.onStart()
         setupViews()
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/TimerFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/TimerFragment.kt
@@ -75,15 +75,14 @@ class TimerFragment : Fragment() {
         view.timers_list.adapter = timerAdapter
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupViews()
+    }
+
     override fun onResume() {
         super.onResume()
-        requireContext().updateTextColors(timer_fragment)
-        val configTextColor = requireContext().getProperTextColor()
-        if (storedTextColor != configTextColor) {
-            initAdapter()
-            timerAdapter.updateTextColor(configTextColor)
-            refreshTimers()
-        }
+        setupViews()
     }
 
     override fun onPause() {
@@ -105,6 +104,16 @@ class TimerFragment : Fragment() {
                     }
                 }
             }
+        }
+    }
+
+    private fun setupViews() {
+        requireContext().updateTextColors(timer_fragment)
+        val configTextColor = requireContext().getProperTextColor()
+        if (storedTextColor != configTextColor) {
+            initAdapter()
+            timerAdapter.updateTextColor(configTextColor)
+            refreshTimers()
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.duolingo.open.rtlviewpager.RtlViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
### Notes:

- In the older ViewPager (thanks to android debugger), `onResume()` was called as soon as the fragment is created doesn't matter whether it's visible or not. **With ViewPager2, we have to ensure the views are set up properly in `onViewCreated()`** to avoid visible delays as [`onResume()`](https://github.com/xxv/android-lifecycle/blob/main/android-lifecycle-activity-to-fragments.png) is called at a later, perfectly valid, stage when the fragment is actually visible to the user. 
- As per [this page](https://developer.android.com/training/animation/vp2-migration), RTL paging is enabled automatically where appropriate based on locale (tested and works) but it's also possible to do so manually using `setLayoutDirection()`.