### PR TITLE
Refactor of `showOverLockscreen` function

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
@@ -264,17 +264,16 @@ class ReminderActivity : SimpleActivity() {
     }
 
     private fun showOverLockscreen() {
-        window.addFlags(
-            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
-                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
-                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-                WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
-        )
-
         if (isOreoMr1Plus()) {
             setShowWhenLocked(true)
             setTurnScreenOn(true)
             (getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager).requestDismissKeyguard(this, null)
+        } else {
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
+                    WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+            )
         }
     }
 }


### PR DESCRIPTION
I was not able to reproduce the issue of needing to unlock my phone to see the alarm with USB cable connected and USB debugging on. (Tested on Samsung Note 9 - Android 13 & Xiaomi Redmi Note 10 - Android 11)

However, looking at this StackOverflow answer https://stackoverflow.com/a/55998126/13908824, I've moved the window flag manipulation part of the `showOverLockscreen` function to the else block which executes only if the OS version is less than 27 which was otherwise executing for both cases i.e above and below SDK 27.

I'm not sure if this will fix the issue of needing to unlock the phone for the alarm as I'm not able to reproduce it on my end

