### PR TITLE
add USE_EXACT_ALARM to be granted on install.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
#[ISSUE-474](https://github.com/SimpleMobileTools/Simple-Clock/issues/474) Add USE_EXACT_ALARM permission. Is new permission that is only to be used by [Calendar or alarm clock apps](https://support.google.com/googleplay/android-developer/answer/12253906#exact_alarm_preview)

[According to documentation](https://developer.android.com/about/versions/14/changes/schedule-exact-alarms): The USE_EXACT_ALARM permission will be granted on installation, and apps holding this permission will be able to schedule exact alarms just like apps with the [SCHEDULE_EXACT_ALARM](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM) permission.
