### PR TITLE
Fix #435

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,8 @@
 
         <activity
             android:name=".activities.ReminderActivity"
+            android:excludeFromRecents="true"
+            android:taskAffinity=".ReminderActivity"
             android:configChanges="orientation"
             android:exported="false"
             android:launchMode="singleTask"


### PR DESCRIPTION
A fix for #435
Removes the alarm activity (ReminderActivity) from the Recents menu