### PR TITLE
replace handler with timer for stopwatch tasks

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/StopwatchFragment.kt
@@ -199,13 +199,17 @@ class StopwatchFragment : Fragment() {
 
     private val updateListener = object : Stopwatch.UpdateListener {
         override fun onUpdate(totalTime: Long, lapTime: Long, useLongerMSFormat: Boolean) {
-            updateDisplayedText(totalTime, lapTime, useLongerMSFormat)
+            activity?.run {
+                updateDisplayedText(totalTime, lapTime, useLongerMSFormat)
+            }
         }
 
         override fun onStateChanged(state: Stopwatch.State) {
-            updateIcons(state)
-            binding.stopwatchLap.beVisibleIf(state == Stopwatch.State.RUNNING)
-            binding.stopwatchReset.beVisibleIf(state != Stopwatch.State.STOPPED)
+            activity?.run {
+                updateIcons(state)
+                binding.stopwatchLap.beVisibleIf(state == Stopwatch.State.RUNNING)
+                binding.stopwatchReset.beVisibleIf(state != Stopwatch.State.STOPPED)
+            }
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/SimpleMobileTools/Simple-Clock/issues/423

- replace "handler" with "timer" for stopwatch tasks as it relatively more resistance to background limitations: handler was running on main looper in here while timer runs on a new thread.

if the consistency still persist later, better solution would be moving all [Stopwatch](https://github.com/SimpleMobileTools/Simple-Clock/blob/master/app/src/main/kotlin/com/simplemobiletools/clock/helpers/Stopwatch.kt) businesses to [StopwatchService](https://github.com/SimpleMobileTools/Simple-Clock/blob/master/app/src/main/kotlin/com/simplemobiletools/clock/services/StopwatchService.kt) then notifying UI layer from there
- fix stopwatch -> update listener add/remove logic for better listener update consistency
- reduce notification update frequency as it doesn't make sense to update notification again and again with the same text: the time is displayed in seconds in notification bar, but the notification was being updated per 100ms.
