### PR TITLE
reset device alarm volume to initial after alarm ends

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
@@ -22,8 +22,8 @@ import com.simplemobiletools.commons.helpers.*
 class ReminderActivity : SimpleActivity() {
     private val INCREASE_VOLUME_DELAY = 300L
 
-    private val increaseVolumeHandler = Handler()
-    private val maxReminderDurationHandler = Handler()
+    private val increaseVolumeHandler = Handler(Looper.getMainLooper())
+    private val maxReminderDurationHandler = Handler(Looper.getMainLooper())
     private val swipeGuideFadeHandler = Handler()
     private val vibrationHandler = Handler(Looper.getMainLooper())
     private var isAlarmReminder = false
@@ -198,19 +198,19 @@ class ReminderActivity : SimpleActivity() {
                 }
 
                 if (config.increaseVolumeGradually) {
-                    scheduleVolumeIncrease(maxVol)
+                    scheduleVolumeIncrease(maxVol, 0)
                 }
             } catch (e: Exception) {
             }
         }
     }
 
-    private fun scheduleVolumeIncrease(maxVolume: Float) {
+    private fun scheduleVolumeIncrease(maxVolume: Float, delay: Long) {
         increaseVolumeHandler.postDelayed({
             lastVolumeValue = (lastVolumeValue + 0.1f).coerceAtMost(maxVolume)
             audioManager?.setStreamVolume(AudioManager.STREAM_ALARM, lastVolumeValue.toInt(), 0)
-            scheduleVolumeIncrease(maxVolume)
-        }, INCREASE_VOLUME_DELAY)
+            scheduleVolumeIncrease(maxVolume, INCREASE_VOLUME_DELAY)
+        }, delay)
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/ReminderActivity.kt
@@ -194,7 +194,6 @@ class ReminderActivity : SimpleActivity() {
                 mediaPlayer = MediaPlayer().apply {
                     setAudioStreamType(AudioManager.STREAM_ALARM)
                     setDataSource(this@ReminderActivity, Uri.parse(soundUri))
-                    setVolume(lastVolumeValue, lastVolumeValue)
                     isLooping = true
                     prepare()
                     start()


### PR DESCRIPTION
fix https://github.com/SimpleMobileTools/Simple-Clock/issues/493

[remove misused and unnecessary media player method setVolume.](https://github.com/SimpleMobileTools/Simple-Clock/commit/09ff33ab84df8f162571a57d9e7b06b12d68998e): solves [...the gradual increase does not reach full volume](https://github.com/SimpleMobileTools/Simple-Clock/issues/493#issuecomment-1677210293)


[respects to user defined alarm volume while increasing it gradually](https://github.com/SimpleMobileTools/Simple-Clock/commit/fef105d98622e8c9f365444e7ef6b0247afc6a74): increasing alarms weren't respecting to device's alarm volume. 
it was reaching device's max alarm volume on gradual increase even user don't set alarm volume to max. 
now, the max allowed volume of gradually increasing alarms are limited to device's alarm volume. 


[adjust initial alarm volume before media player starts playing.](https://github.com/SimpleMobileTools/Simple-Clock/commit/a51886870e97fbf199cfd91a8c1be49dc418ea74): on the gradually increasing alarms, media player was starting to loud before alarm volume lowered. this was causing to hear the alarm sound at max volume for a while while 