### PR TITLE
Added option in settings to toggle seconds visibility from shared pre…

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/SettingsActivity.kt
@@ -36,6 +36,7 @@ class SettingsActivity : SimpleActivity() {
         setupLanguage()
         setupPreventPhoneFromSleeping()
         setupSundayFirst()
+        setupShowSeconds()
         setupAlarmMaxReminder()
         setupUseSameSnooze()
         setupSnoozeTime()
@@ -99,6 +100,14 @@ class SettingsActivity : SimpleActivity() {
         binding.settingsSundayFirstHolder.setOnClickListener {
             binding.settingsSundayFirst.toggle()
             config.isSundayFirst = binding.settingsSundayFirst.isChecked
+        }
+    }
+
+    private fun setupShowSeconds() {
+        binding.settingsShowSeconds.isChecked = config.areSecondsVisible
+        binding.settingsShowSecondsHolder.setOnClickListener {
+            binding.settingsShowSeconds.toggle()
+            config.areSecondsVisible = binding.settingsShowSeconds.isChecked
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/fragments/ClockFragment.kt
@@ -78,6 +78,14 @@ class ClockFragment : Fragment() {
             binding.clockTime.textSize = resources.getDimension(R.dimen.clock_text_size_smaller) / resources.displayMetrics.density
         }
 
+        if (context?.config?.areSecondsVisible == true) {
+            binding.clockTime.format12Hour = "h:mm:ss a"
+            binding.clockTime.format24Hour = "h:mm:ss"
+        } else {
+            binding.clockTime.format12Hour = "h:mm a"
+            binding.clockTime.format24Hour = "h:mm"
+        }
+
         if (seconds == 0) {
             if (hours == 0 && minutes == 0) {
                 updateDate()

--- a/app/src/main/kotlin/com/simplemobiletools/clock/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/helpers/Config.kt
@@ -86,4 +86,8 @@ class Config(context: Context) : BaseConfig(context) {
     var wasInitialWidgetSetUp: Boolean
         get() = prefs.getBoolean(WAS_INITIAL_WIDGET_SET_UP, false)
         set(wasInitialWidgetSetUp) = prefs.edit().putBoolean(WAS_INITIAL_WIDGET_SET_UP, wasInitialWidgetSetUp).apply()
+
+    var areSecondsVisible: Boolean
+        get() = prefs.getBoolean(ARE_SECONDS_VISIBLE, true)
+        set(areSecondsVisible) = prefs.edit().putBoolean(ARE_SECONDS_VISIBLE, areSecondsVisible).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/clock/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/helpers/Constants.kt
@@ -26,6 +26,7 @@ const val INCREASE_VOLUME_GRADUALLY = "increase_volume_gradually"
 const val ALARMS_SORT_BY = "alarms_sort_by"
 const val STOPWATCH_LAPS_SORT_BY = "stopwatch_laps_sort_by"
 const val WAS_INITIAL_WIDGET_SET_UP = "was_initial_widget_set_up"
+const val ARE_SECONDS_VISIBLE = "are_seconds_visible"
 
 const val TABS_COUNT = 4
 const val EDITED_TIME_ZONE_SEPARATOR = ":"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -168,6 +168,32 @@
                 layout="@layout/divider" />
 
             <TextView
+                android:id="@+id/settings_clock_tab_label"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/clock_tab" />
+
+            <RelativeLayout
+                android:id="@+id/settings_show_seconds_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_show_seconds"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/show_seconds" />
+
+            </RelativeLayout>
+
+            <include
+                android:id="@+id/settings_clock_tab_divider"
+                layout="@layout/divider" />
+
+            <TextView
                 android:id="@+id/settings_alarm_tab_label"
                 style="@style/SettingsSectionLabelStyle"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Added option in settings to toggle seconds visibility from shared preferences (true by default).

![settings](https://github.com/SimpleMobileTools/Simple-Clock/assets/113942496/185f4fbf-81d8-4a92-aa7f-dd7c31a37610)
![with_seconds](https://github.com/SimpleMobileTools/Simple-Clock/assets/113942496/b615fe95-9845-4b58-b68e-783afad9ded0)
![without_seconds](https://github.com/SimpleMobileTools/Simple-Clock/assets/113942496/986ea945-1d2d-41ee-a7ae-080d83ea69dc)
