### PR TITLE
Fix #533

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
 
         <activity
             android:name=".activities.ReminderActivity"
-            android:configChanges="orientation"
+            android:configChanges="orientation|screenSize"
             android:excludeFromRecents="true"
             android:exported="false"
             android:launchMode="singleTask"


### PR DESCRIPTION
Does not affect 

>it seems that the screen needs to be turned off when the alarm gets triggered, if the phone is currently in use when the alarm gets triggered there is only a notification being displayed and the alarm clock does not show up in task manager.

as that is prolly intended behaviour