### PR TITLE
Fix #533 - Alarm stops ringing on screen rotated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,7 @@
 
         <activity
             android:name=".activities.ReminderActivity"
-            android:configChanges="orientation"
+            android:configChanges="orientation|screenSize|screenLayout"
             android:excludeFromRecents="true"
             android:exported="false"
             android:launchMode="singleTask"


### PR DESCRIPTION
Fix #533 Added "screenSize|screenLayout" to manifest to ReminderActivity. Here is a short video how it works now https://youtube.com/shorts/VBJdPQ94y7g 
