### PR TITLE
Add new vertical digital clock widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,16 @@
         </activity>
 
         <activity
+            android:name=".activities.WidgetVerticalDigitalConfigureActivity"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:theme="@style/MyWidgetConfigTheme">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".activities.WidgetAnalogueConfigureActivity"
             android:exported="true"
             android:screenOrientation="portrait"
@@ -192,6 +202,21 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_digital_clock_info" />
+        </receiver>
+
+        <receiver
+            android:name=".helpers.MyVerticalDigitalTimeWidgetProvider"
+            android:exported="true"
+            android:label="@string/vertical_digital_clock">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="android.appwidget.action.APPWIDGET_ENABLED" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_vertical_digital_clock_info" />
         </receiver>
 
         <receiver

--- a/app/src/main/kotlin/com/simplemobiletools/clock/activities/WidgetVerticalDigitalConfigureActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/activities/WidgetVerticalDigitalConfigureActivity.kt
@@ -1,0 +1,157 @@
+package com.simplemobiletools.clock.activities
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.widget.SeekBar
+import com.simplemobiletools.clock.databinding.WidgetConfigVerticalDigitalBinding
+import com.simplemobiletools.clock.extensions.config
+import com.simplemobiletools.clock.helpers.MyVerticalDigitalTimeWidgetProvider
+import com.simplemobiletools.clock.helpers.SIMPLE_PHONE
+import com.simplemobiletools.commons.dialogs.ColorPickerDialog
+import com.simplemobiletools.commons.dialogs.FeatureLockedDialog
+import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.helpers.IS_CUSTOMIZING_COLORS
+
+class WidgetVerticalDigitalConfigureActivity : SimpleActivity() {
+    private var mBgAlpha = 0f
+    private var mWidgetId = 0
+    private var mBgColor = 0
+    private var mTextColor = 0
+    private var mBgColorWithoutTransparency = 0
+    private var mFeatureLockedDialog: FeatureLockedDialog? = null
+    private val binding: WidgetConfigVerticalDigitalBinding by viewBinding(WidgetConfigVerticalDigitalBinding::inflate)
+
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        useDynamicTheme = false
+        super.onCreate(savedInstanceState)
+        setResult(Activity.RESULT_CANCELED)
+        setContentView(binding.root)
+        initVariables()
+
+        mWidgetId = intent.extras?.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (!config.wasInitialWidgetSetUp && Build.BRAND.equals(SIMPLE_PHONE, true)) {
+            saveConfig()
+            config.wasInitialWidgetSetUp = true
+            return
+        }
+
+        val isCustomizingColors = intent.extras?.getBoolean(IS_CUSTOMIZING_COLORS) ?: false
+        if (mWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID && !isCustomizingColors) {
+            finish()
+        }
+
+        binding.configDigitalSave.setOnClickListener { saveConfig() }
+        binding.configDigitalBgColor.setOnClickListener { pickBackgroundColor() }
+        binding.configDigitalTextColor.setOnClickListener { pickTextColor() }
+
+        val primaryColor = getProperPrimaryColor()
+        binding.configDigitalBgSeekbar.setColors(mTextColor, primaryColor, primaryColor)
+
+        if (!isCustomizingColors && !isOrWasThankYouInstalled()) {
+            mFeatureLockedDialog = FeatureLockedDialog(this) {
+                if (!isOrWasThankYouInstalled()) {
+                    finish()
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (mFeatureLockedDialog != null && isOrWasThankYouInstalled()) {
+            mFeatureLockedDialog?.dismissDialog()
+        }
+    }
+
+    private fun initVariables() {
+        mBgColor = config.widgetBgColor
+        mBgAlpha = Color.alpha(mBgColor) / 255.toFloat()
+        mBgColorWithoutTransparency = Color.rgb(Color.red(mBgColor), Color.green(mBgColor), Color.blue(mBgColor))
+
+        binding.configDigitalBgSeekbar.setOnSeekBarChangeListener(bgSeekbarChangeListener)
+        binding.configDigitalBgSeekbar.progress = (mBgAlpha * 100).toInt()
+        updateBackgroundColor()
+
+        mTextColor = config.widgetTextColor
+        if (mTextColor == resources.getColor(com.simplemobiletools.commons.R.color.default_widget_text_color) && config.isUsingSystemTheme) {
+            mTextColor = resources.getColor(com.simplemobiletools.commons.R.color.you_primary_color, theme)
+        }
+
+        updateTextColor()
+    }
+
+    private fun saveConfig() {
+        storeWidgetColors()
+        requestWidgetUpdate()
+
+        Intent().apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, mWidgetId)
+            setResult(Activity.RESULT_OK, this)
+        }
+        finish()
+    }
+
+    private fun storeWidgetColors() {
+        config.apply {
+            widgetBgColor = mBgColor
+            widgetTextColor = mTextColor
+        }
+    }
+
+    private fun pickBackgroundColor() {
+        ColorPickerDialog(this, mBgColorWithoutTransparency) { wasPositivePressed, color ->
+            if (wasPositivePressed) {
+                mBgColorWithoutTransparency = color
+                updateBackgroundColor()
+            }
+        }
+    }
+
+    private fun pickTextColor() {
+        ColorPickerDialog(this, mTextColor) { wasPositivePressed, color ->
+            if (wasPositivePressed) {
+                mTextColor = color
+                updateTextColor()
+            }
+        }
+    }
+
+    private fun requestWidgetUpdate() {
+        Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE, null, this, MyVerticalDigitalTimeWidgetProvider::class.java).apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(mWidgetId))
+            sendBroadcast(this)
+        }
+    }
+
+    private fun updateTextColor() {
+        binding.configDigitalTextColor.setFillWithStroke(mTextColor, mTextColor)
+        binding.configDigitalTimeHour.setTextColor(mTextColor)
+        binding.configDigitalTimeMinute.setTextColor(mTextColor)
+        binding.configDigitalDate.setTextColor(mTextColor)
+        binding.configDigitalSave.setTextColor(getProperPrimaryColor().getContrastColor())
+    }
+
+    private fun updateBackgroundColor() {
+        mBgColor = mBgColorWithoutTransparency.adjustAlpha(mBgAlpha)
+        binding.configDigitalBgColor.setFillWithStroke(mBgColor, mBgColor)
+        binding.configDigitalBackground.applyColorFilter(mBgColor)
+        binding.configDigitalSave.backgroundTintList = ColorStateList.valueOf(getProperPrimaryColor())
+    }
+
+    private val bgSeekbarChangeListener = object : SeekBar.OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+            mBgAlpha = progress.toFloat() / 100.toFloat()
+            updateBackgroundColor()
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar) {}
+
+        override fun onStopTrackingTouch(seekBar: SeekBar) {}
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/clock/helpers/MyVerticalDigitalTimeWidgetProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/clock/helpers/MyVerticalDigitalTimeWidgetProvider.kt
@@ -1,0 +1,90 @@
+package com.simplemobiletools.clock.helpers
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.*
+import android.os.Bundle
+import android.widget.RemoteViews
+import com.simplemobiletools.clock.R
+import com.simplemobiletools.clock.activities.SplashActivity
+import com.simplemobiletools.clock.extensions.config
+import com.simplemobiletools.clock.extensions.getClosestEnabledAlarmString
+import com.simplemobiletools.commons.extensions.applyColorFilter
+import com.simplemobiletools.commons.extensions.getLaunchIntent
+import com.simplemobiletools.commons.extensions.setText
+import com.simplemobiletools.commons.extensions.setVisibleIf
+
+class MyVerticalDigitalTimeWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        performUpdate(context)
+    }
+
+    private fun performUpdate(context: Context) {
+        val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+        context.getClosestEnabledAlarmString { nextAlarm ->
+            appWidgetManager.getAppWidgetIds(getComponentName(context)).forEach {
+                RemoteViews(context.packageName, R.layout.widget_vertical_digital).apply {
+                    updateTexts(context, this, nextAlarm)
+                    updateColors(context, this)
+                    setupAppOpenIntent(context, this)
+                    appWidgetManager.updateAppWidget(it, this)
+                }
+            }
+        }
+    }
+
+    private fun updateTexts(context: Context, views: RemoteViews, nextAlarm: String) {
+        views.apply {
+            setText(R.id.widget_next_alarm, nextAlarm)
+            setVisibleIf(R.id.widget_alarm_holder, nextAlarm.isNotEmpty())
+        }
+    }
+
+    private fun updateColors(context: Context, views: RemoteViews) {
+        val config = context.config
+        val widgetTextColor = config.widgetTextColor
+
+        views.apply {
+            applyColorFilter(R.id.widget_background, config.widgetBgColor)
+            setTextColor(R.id.widget_text_clock_hour, widgetTextColor)
+            setTextColor(R.id.widget_text_clock_minute, widgetTextColor)
+            setTextColor(R.id.widget_date, widgetTextColor)
+            setTextColor(R.id.widget_next_alarm, widgetTextColor)
+
+            val bitmap = getMultiplyColoredBitmap(R.drawable.ic_clock_shadowed, widgetTextColor, context)
+            setImageViewBitmap(R.id.widget_next_alarm_image, bitmap)
+        }
+    }
+
+    private fun getComponentName(context: Context) = ComponentName(context, this::class.java)
+
+    private fun setupAppOpenIntent(context: Context, views: RemoteViews) {
+        (context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)).apply {
+            putExtra(OPEN_TAB, TAB_CLOCK)
+            val pendingIntent = PendingIntent.getActivity(context, OPEN_APP_INTENT_ID, this, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            views.setOnClickPendingIntent(R.id.widget_date_time_holder, pendingIntent)
+        }
+    }
+
+    override fun onAppWidgetOptionsChanged(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int, newOptions: Bundle?) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+        performUpdate(context)
+    }
+
+    private fun getMultiplyColoredBitmap(resourceId: Int, newColor: Int, context: Context): Bitmap {
+        val options = BitmapFactory.Options()
+        options.inMutable = true
+        val bmp = BitmapFactory.decodeResource(context.resources, resourceId, options)
+        val paint = Paint()
+        val filter = PorterDuffColorFilter(newColor, PorterDuff.Mode.MULTIPLY)
+        paint.colorFilter = filter
+        val canvas = Canvas(bmp)
+        canvas.drawBitmap(bmp, 0f, 0f, paint)
+        return bmp
+    }
+}

--- a/app/src/main/res/layout/widget_config_vertical_digital.xml
+++ b/app/src/main/res/layout/widget_config_vertical_digital.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/config_coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:id="@+id/config_digital_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_margin="@dimen/activity_margin">
+
+        <RelativeLayout
+            android:id="@+id/config_digital_wrapper"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/small_margin">
+
+            <ImageView
+                android:id="@+id/config_digital_background"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignBottom="@+id/config_digital_date"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentEnd="true"
+                android:src="@drawable/widget_round_background" />
+
+            <TextClock
+                android:id="@+id/config_digital_time_hour"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/widget_digital_time_height"
+                android:format12Hour="h"
+                android:format24Hour="k"
+                android:gravity="center_horizontal"
+                android:includeFontPadding="false"
+                android:shadowColor="@android:color/black"
+                android:shadowDy="1"
+                android:shadowRadius="1"
+                android:textSize="@dimen/widget_time_text_size_small"
+                tools:text="00" />
+
+            <TextClock
+                android:id="@+id/config_digital_time_minute"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/widget_digital_time_height"
+                android:layout_below="@+id/config_digital_time_hour"
+                android:format12Hour="mm"
+                android:format24Hour="mm"
+                android:gravity="center_horizontal"
+                android:includeFontPadding="false"
+                android:shadowColor="@android:color/black"
+                android:shadowDy="1"
+                android:shadowRadius="1"
+                android:textSize="@dimen/widget_time_text_size_small"
+                tools:text="00" />
+
+            <TextClock
+                android:id="@+id/config_digital_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/config_digital_time_minute"
+                android:format12Hour="EEE, d MMM"
+                android:format24Hour="EEE, d MMM"
+                android:gravity="center_horizontal"
+                android:includeFontPadding="false"
+                android:paddingBottom="@dimen/small_margin"
+                android:shadowColor="@android:color/black"
+                android:shadowDy="1"
+                android:shadowRadius="1"
+                android:textSize="@dimen/normal_text_size"
+                tools:text="Mon, 1 January" />
+
+        </RelativeLayout>
+
+        <ImageView
+            android:id="@+id/config_digital_bg_color"
+            android:layout_width="@dimen/widget_colorpicker_size"
+            android:layout_height="@dimen/widget_colorpicker_size"
+            android:layout_above="@+id/config_digital_text_color"
+            android:layout_margin="@dimen/tiny_margin" />
+
+        <RelativeLayout
+            android:id="@+id/config_digital_seekbar_holder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignTop="@+id/config_digital_bg_color"
+            android:layout_alignBottom="@+id/config_digital_bg_color"
+            android:layout_marginStart="@dimen/medium_margin"
+            android:layout_toEndOf="@+id/config_digital_bg_color"
+            android:background="@drawable/widget_config_seekbar_background">
+
+            <com.simplemobiletools.commons.views.MySeekBar
+                android:id="@+id/config_digital_bg_seekbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:paddingStart="@dimen/activity_margin"
+                android:paddingEnd="@dimen/activity_margin" />
+
+        </RelativeLayout>
+
+        <ImageView
+            android:id="@+id/config_digital_text_color"
+            android:layout_width="@dimen/widget_colorpicker_size"
+            android:layout_height="@dimen/widget_colorpicker_size"
+            android:layout_alignParentBottom="true"
+            android:layout_margin="@dimen/tiny_margin" />
+
+        <Button
+            android:id="@+id/config_digital_save"
+            style="@style/MyWidgetConfigSaveStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentBottom="true"
+            android:text="@string/ok" />
+
+    </RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/widget_vertical_digital.xml
+++ b/app/src/main/res/layout/widget_vertical_digital.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_holder"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/widget_background"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:src="@drawable/widget_round_background" />
+
+    <LinearLayout
+        android:id="@+id/widget_date_time_holder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingLeft="@dimen/small_margin"
+        android:paddingRight="@dimen/small_margin"
+        android:paddingBottom="@dimen/small_margin"
+        tools:ignore="UnusedAttribute">
+
+        <TextClock
+            android:id="@+id/widget_text_clock_hour"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="4"
+            android:autoSizeMaxTextSize="300sp"
+            android:autoSizeMinTextSize="2sp"
+            android:autoSizeStepGranularity="1sp"
+            android:autoSizeTextType="uniform"
+            android:format12Hour="h"
+            android:format24Hour="k"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:shadowColor="@android:color/black"
+            android:shadowDy="1"
+            android:shadowRadius="1"
+            android:textSize="@dimen/normal_text_size"
+            tools:text="00" />
+
+        <TextClock
+            android:id="@+id/widget_text_clock_minute"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="4"
+            android:autoSizeMaxTextSize="300sp"
+            android:autoSizeMinTextSize="2sp"
+            android:autoSizeStepGranularity="1sp"
+            android:autoSizeTextType="uniform"
+            android:format12Hour="mm"
+            android:format24Hour="mm"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:shadowColor="@android:color/black"
+            android:shadowDy="1"
+            android:shadowRadius="1"
+            android:textSize="@dimen/normal_text_size"
+            tools:text="00" />
+
+        <TextClock
+            android:id="@+id/widget_date"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:autoSizeMinTextSize="2sp"
+            android:autoSizeStepGranularity="1sp"
+            android:autoSizeTextType="uniform"
+            android:format12Hour="EEE, d MMM"
+            android:format24Hour="EEE, d MMM"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:shadowColor="@android:color/black"
+            android:shadowDy="1"
+            android:shadowRadius="1"
+            android:textSize="@dimen/normal_text_size"
+            tools:text="Mon, 1 January" />
+
+        <RelativeLayout
+            android:id="@+id/widget_alarm_holder"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center_horizontal">
+
+            <ImageView
+                android:id="@+id/widget_next_alarm_image"
+                android:layout_width="@dimen/widget_alarm_icon_size"
+                android:layout_height="@dimen/widget_alarm_icon_size"
+                android:layout_alignTop="@+id/widget_next_alarm"
+                android:layout_alignBottom="@+id/widget_next_alarm"
+                android:src="@drawable/ic_alarm_vector" />
+
+            <TextView
+                android:id="@+id/widget_next_alarm"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_toEndOf="@+id/widget_next_alarm_image"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:maxLines="1"
+                android:paddingStart="@dimen/small_margin"
+                android:shadowColor="@android:color/black"
+                android:shadowDy="1"
+                android:shadowRadius="1"
+                android:textSize="@dimen/normal_text_size"
+                tools:text="Tue, 18:30" />
+
+        </RelativeLayout>
+    </LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">اليوم ووقت التنبيه</string>
     <string name="analogue_clock">ساعة تناظرية</string>
     <string name="digital_clock">ساعة رقمية</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">تم تجاهل المنبه</string>
     <string name="select_timer_to_dismiss">حدد موقت لرفضه</string>
     <string name="select_alarm_to_dismiss">حدد منبه لتجاهله</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -21,6 +21,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Дзень і час будзільніка</string>
     <string name="analogue_clock">Аналагавы гадзіннік</string>
     <string name="digital_clock">Лічбавы гадзіннік</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Будзільнік адхілены</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Ден и час на алармата</string>
     <string name="analogue_clock">Аналогов часовник</string>
     <string name="digital_clock">Цифров часовник</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Алармата е отхвърлена</string>
     <string name="select_timer_to_dismiss">Избери таймер за отхвърляне</string>
     <string name="select_alarm_to_dismiss">Избери аларма за отхвърляне</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dia i hora d\'alarma</string>
     <string name="analogue_clock">Rellotge analògic</string>
     <string name="digital_clock">Rellotge digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarma descartada</string>
     <string name="select_timer_to_dismiss">Seleccioneu el temporitzador a descartar</string>
     <string name="select_alarm_to_dismiss">Seleccioneu l\'alarma a descartar</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dne a času budíku</string>
     <string name="analogue_clock">Analogové hodiny</string>
     <string name="digital_clock">Digitální hodiny</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Budík zrušen</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -21,6 +21,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Tag und Weckzeit</string>
     <string name="analogue_clock">Analoge Uhr</string>
     <string name="digital_clock">Digitale Uhr</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm unterdrückt</string>
     <string name="select_timer_to_dismiss">Zu unterdrückenden Timer auswählen</string>
     <string name="select_alarm_to_dismiss">Zu unterdrückenden Alarm auswählen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Ημέρα και ώρα αφύπνισης</string>
     <string name="analogue_clock">Αναλογικό Ρολόι</string>
     <string name="digital_clock">Ψηφιακό Ρολόι</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Η αφύπνιση απορρίφθηκε</string>
     <string name="select_timer_to_dismiss">Επιλέξτε χρονοδιακόπτη για απόρριψη</string>
     <string name="select_alarm_to_dismiss">Επιλέξτε συναγερμό για απόρριψη</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Día y hora de la alarma</string>
     <string name="analogue_clock">Reloj analógico</string>
     <string name="digital_clock">Reloj digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarma desechada</string>
     <string name="select_timer_to_dismiss">Selecciona el temporizador que quieres descartar</string>
     <string name="select_alarm_to_dismiss">Selecciona la alarma que quieres descartar</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Päev ja äratuse aeg</string>
     <string name="analogue_clock">Sihverplaadiga kell</string>
     <string name="digital_clock">Numbritega kell</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Äratus on tühistatud</string>
     <string name="select_timer_to_dismiss">Vali eemaldatav taimer</string>
     <string name="select_alarm_to_dismiss">Vali eemaldatav äratus</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Eguna eta alarma-ordua</string>
     <string name="analogue_clock">Erloju analogikoa</string>
     <string name="digital_clock">Erloju digitala</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarma baztertu da</string>
     <string name="select_timer_to_dismiss">Hautatu baztertu nahi duzun tenporizadorea</string>
     <string name="select_alarm_to_dismiss">Hautatu baztertu nahi duzun alarma</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Päivä ja Herätysaika</string>
     <string name="analogue_clock">Analoginen kello</string>
     <string name="digital_clock">Digitaalinen kello</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Herätys lopetettiin</string>
     <string name="select_timer_to_dismiss">Valitse hylättävä ajastus</string>
     <string name="select_alarm_to_dismiss">Valitse hylättävä herätys</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Jour et heure de l\'alarme</string>
     <string name="analogue_clock">Horloge analogique</string>
     <string name="digital_clock">Horloge numérique</string>
+    <string name="vertical_digital_clock">Horloge numérique verticale</string>
     <string name="alarm_dismissed">Alarme rejetée</string>
     <string name="select_timer_to_dismiss">Sélectionnez le minuteur à ignorer</string>
     <string name="select_alarm_to_dismiss">Sélectionnez l\'alarme à ignorer</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Día e hora dá alarma</string>
     <string name="analogue_clock">Reloxo analóxico</string>
     <string name="digital_clock">Reloxo dixital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarma descartada</string>
     <string name="select_timer_to_dismiss">Elixe o temporizador a desbotar</string>
     <string name="select_alarm_to_dismiss">Elixe a alarma a desbotar</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dan i vrijeme alarma</string>
     <string name="analogue_clock">Analogni sat</string>
     <string name="digital_clock">Digitalni sat</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm odbačen</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Nap és ébresztési idő</string>
     <string name="analogue_clock">Analóg óra</string>
     <string name="digital_clock">Digitális óra</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Riasztás eltüntetve</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Waktu Hari dan Alarm</string>
     <string name="analogue_clock">Jam analog</string>
     <string name="digital_clock">Jam digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm diabaikan</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Giorno e ora sveglia</string>
     <string name="analogue_clock">Orologio analogico</string>
     <string name="digital_clock">Orologio digitale</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Allarme disattivato</string>
     <string name="select_timer_to_dismiss">Seleziona il contaminuti da disattivare</string>
     <string name="select_alarm_to_dismiss">Seleziona l\'allarme da disattivare</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">התראה יום ושעה</string>
     <string name="analogue_clock">שעון אנלוגי</string>
     <string name="digital_clock">שעון דיגיטלי</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">曜日とアラーム時刻</string>
     <string name="analogue_clock">アナログ時計</string>
     <string name="digital_clock">デジタル時計</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">アラームが破棄されました</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -21,6 +21,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">ദിവസവും അലാറം സമയവും</string>
     <string name="analogue_clock">അനലോഗ് ക്ലോക്ക്</string>
     <string name="digital_clock">ഡിജിറ്റൽ ക്ലോക്ക്</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">അലാറം ഒഴിവാക്കി</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -24,6 +24,7 @@
     <string name="sort_by_day_and_alarm_time">နေ့ရက် နှင့် နှိုးစက်အချိန်ဖြင့်</string>
     <string name="analogue_clock">တိုင်ကပ်နာရီ</string>
     <string name="digital_clock">ဒီဂျစ်တယ်နာရီ</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">နှိုးစက်အားဖယ်ရှားပြီး</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dag og alarmtid</string>
     <string name="analogue_clock">Analog klokke</string>
     <string name="digital_clock">Digital klokke</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm slått av</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dag en tijd</string>
     <string name="analogue_clock">Analoge klok</string>
     <string name="digital_clock">Digitale klok</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Wekker uitgezet</string>
     <string name="select_timer_to_dismiss">Timer uitzetten</string>
     <string name="select_alarm_to_dismiss">Wekker uitzetten</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -23,6 +23,7 @@
     <string name="sort_by_day_and_alarm_time">دن تے الارم سماں</string>
     <string name="analogue_clock">اینولوگ گھڑی</string>
     <string name="digital_clock">ڈیجیٹل گھڑی</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">الارم بند کیتا گیا</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dzień i godzina alarmu</string>
     <string name="analogue_clock">Zegar analogowy</string>
     <string name="digital_clock">Zegar cyfrowy</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm odrzucony</string>
     <string name="select_timer_to_dismiss">Wybierz minutnik do odrzucenia</string>
     <string name="select_alarm_to_dismiss">Wybierz alarm do odrzucenia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dia e hora do alarme</string>
     <string name="analogue_clock">Relógio analógico</string>
     <string name="digital_clock">Relógio digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarme descartado</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dia e hora do alarme</string>
     <string name="analogue_clock">Relógio analógico</string>
     <string name="digital_clock">Relógio digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarme descartado</string>
     <string name="select_timer_to_dismiss">Selecione o temporizador a descartar</string>
     <string name="select_alarm_to_dismiss">Selecione o alarme a descartar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Ziua și ora alarmei</string>
     <string name="analogue_clock">Ceas analogic</string>
     <string name="digital_clock">Ceas digital</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarmă ignorată</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Дата и время будильника</string>
     <string name="analogue_clock">Аналоговые часы</string>
     <string name="digital_clock">Цифровые часы</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Будильник отключён</string>
     <string name="select_timer_to_dismiss">Выберите таймер для отключения</string>
     <string name="select_alarm_to_dismiss">Выберите будильник для отключения</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dňa a času budíka</string>
     <string name="analogue_clock">Analógové hodiny</string>
     <string name="digital_clock">Digitálne hodiny</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Budík bol zastavený</string>
     <string name="select_timer_to_dismiss">Zvoľte časovač na zrušenie</string>
     <string name="select_alarm_to_dismiss">Zvoľte budík na zrušenie</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dan in čas budilke</string>
     <string name="analogue_clock">Analogna ura</string>
     <string name="digital_clock">Digitalna ura</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Prekinjen alarm</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -23,6 +23,7 @@
     <string name="analogue_clock">Аналогни сат</string>
     <string name="alarm_snoozed">Аларм је одложен %s</string>
     <string name="digital_clock">Дигитални сат</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Аларм одбачен</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Dag och alarmtid</string>
     <string name="analogue_clock">Analog klocka</string>
     <string name="digital_clock">Digital klocka</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarmet har avvisats</string>
     <string name="select_timer_to_dismiss">Välj timer att avfärda</string>
     <string name="select_alarm_to_dismiss">Välj alarm att avfärda</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Gün ve Alarm zamanı</string>
     <string name="analogue_clock">Analog saat</string>
     <string name="digital_clock">Dijital saat</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm kapatıldı</string>
     <string name="select_timer_to_dismiss">Kapatılacak zamanlayıcıyı seç</string>
     <string name="select_alarm_to_dismiss">Kapatılacak alarmı seç</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">День і час будильника</string>
     <string name="analogue_clock">Аналоговий годинник</string>
     <string name="digital_clock">Цифровий годинник</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Будильник вимкнено</string>
     <string name="select_timer_to_dismiss">Виберіть таймер для відхилення</string>
     <string name="select_alarm_to_dismiss">Виберіть будильник для відхилення</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">天和闹铃时间</string>
     <string name="analogue_clock">指针式时钟</string>
     <string name="digital_clock">数字时钟</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">闹钟已停止</string>
     <string name="select_timer_to_dismiss">选择要放弃的定时器</string>
     <string name="select_alarm_to_dismiss">选择要放弃的闹铃</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="sort_by_day_and_alarm_time">Day and Alarm time</string>
     <string name="analogue_clock">Analogue clock</string>
     <string name="digital_clock">Digital clock</string>
+    <string name="vertical_digital_clock">Vertical Digital clock</string>
     <string name="alarm_dismissed">Alarm dismissed</string>
     <string name="select_timer_to_dismiss">Select timer to dismiss</string>
     <string name="select_alarm_to_dismiss">Select alarm to dismiss</string>

--- a/app/src/main/res/xml/widget_vertical_digital_clock_info.xml
+++ b/app/src/main/res/xml/widget_vertical_digital_clock_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="com.simplemobiletools.clock.activities.WidgetVerticalDigitalConfigureActivity"
+    android:initialLayout="@layout/widget_vertical_digital"
+    android:minWidth="180dp"
+    android:minHeight="40dp"
+    android:minResizeWidth="40dp"
+    android:previewImage="@drawable/img_digital_widget_preview"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="3"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="86400000" />


### PR DESCRIPTION
Hello, some users reported that they wanted more styles for their widget. [Issue 19](https://github.com/SimpleMobileTools/Simple-Clock/issues/19) and I'm willing to work on this.

I'm marking this PR as a draft because :

- This particular design was not reported.
- I'm not sure if you are interested in adding such feature or if it too many widgets would just bloat the app.
- I'm not sure if this should be the correct way to add multiple widget style.
- The preview image is missing and there is a bug when changing the text or the background color.

This is what it currently looks like :
![vertical_digital_clock](https://github.com/SimpleMobileTools/Simple-Clock/assets/39135270/14ac177a-6261-4bbf-88bd-276837ee712b)
